### PR TITLE
mysql/lib: Only do `yum --allowerasing` when not rhel-6

### DIFF
--- a/mysql/lib.sh
+++ b/mysql/lib.sh
@@ -512,7 +512,11 @@ mysqlLibraryLoaded() {
         if ! rpm -q $MYSQL_COMP ; then
             rlLog "MySQL is not installed. Install it."
             [ -d /var/lib/mysql ] && rlRun "rm -rf /var/lib/mysql"
-            rlRun "yum install -y --disablerepo=beaker-tasks --allowerasing $MYSQL_COMP $MYSQL_COMP-server"
+            allowerasing="--allowerasing"
+            if rlIsRHEL 6; then
+                allowerasing=""
+            fi
+            rlRun "yum install -y --disablerepo=beaker-tasks ${allowerasing} $MYSQL_COMP $MYSQL_COMP-server"
         fi
     fi
 


### PR DESCRIPTION
The argument `--allowerasing` is not available in rhel-6, so it is causing a failure in httpd regression tests for rhel-6